### PR TITLE
fix(additional-assets): adds missing method

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -169,6 +169,7 @@ class SVGSpritePlugin {
           compilation.assets[`${this.filenamePrefix}${filename}`] = {
             source() { return content; },
             size() { return content.length; }
+            updateHash(bulkUpdateDecorator) { bulkUpdateDecorator.update(content); }
           };
         });
     });


### PR DESCRIPTION
When using the plugin with `extract: true` config option along `compression-webpack-plugin`, `webpack.cache.PackFileCacheStrategy` crashes.

This fixes the issue by defining the expected method.

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change?**

**Please check if the PR fulfills [contributing guidelines](https://github.com/JetBrains/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
